### PR TITLE
Fix youdao translation bug

### DIFF
--- a/esoda/views.py
+++ b/esoda/views.py
@@ -94,7 +94,7 @@ def esoda_view(request):
                 logger.exception('Failed to parse youdao_translate result: "%s"', trans['explanationList'])
 
     if q == "": # no result from youdao
-        pass
+        q = "***"
     q, ques, aste = refine_query(q) # ques(aste) is the place of question mark(asterisk)
     qt, ref, poss, dep = lemmatize(q, timeout=5)
     expand = []

--- a/esoda/views.py
+++ b/esoda/views.py
@@ -88,10 +88,13 @@ def esoda_view(request):
         trans = youdao_translate(q0, timeout=5)
         if trans.get('explanationList'):
             try:
-                q = trans['explanationList'][0][trans['explanationList'][0].find(']')+1:].strip()
+                # q = trans['explanationList'][0][trans['explanationList'][0].find(']')+1:].strip()
+                q = trans["explanationList"]
             except Exception as e:
                 logger.exception('Failed to parse youdao_translate result: "%s"', trans['explanationList'])
 
+    if q == "": # no result from youdao
+        pass
     q, ques, aste = refine_query(q) # ques(aste) is the place of question mark(asterisk)
     qt, ref, poss, dep = lemmatize(q, timeout=5)
     expand = []

--- a/esoda/youdao_query.py
+++ b/esoda/youdao_query.py
@@ -119,8 +119,17 @@ def youdao_translate_old(q, timeout=10):
     except Exception:
         logger.exception('Failed in Youdao translate "%s"', q)
         return {}
+    basic_explains = r.get('basic', {}).get('explains', [])
+    if basic_explains == []:
+        explanation_str = r.get('translation', [])[0]
+    else:
+        explanation_str = basic_explains[0][basic_explains[0].find(']')+1:].strip()
+        if has_cn(explanation_str):
+            explanation_str = r.get('translation', [])[0]
+
     translated = {
-        'explanationList': r.get('basic', {}).get('explains', []) + r.get('translation', []),
+        # 'explanationList': r.get('basic', {}).get('explains', []) + r.get('translation', []),
+        'explanationList': explanation_str,
         'cached': response.from_cache if hasattr(response, 'from_cache') else False
     }
     logger.info('youdao_translate: "%s" -> %s', r.get('query', q), repr(translated))


### PR DESCRIPTION
If "explains" is not empty, system will choose "explains" as the translation result.
If "explains" is empty and "translation" is not empty, system will choose "explains" as the translation result.
If they are both empty, system will use "***" as the translation result which assures the website won't crash.